### PR TITLE
Added dockerfiles for front and backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.expo
+ios
+android
+.git
+.env
+*.log
+npm-debug.log*
+coverage

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY backend/ ./backend/
+
+EXPOSE 3000
+
+CMD ["node", "backend/server.js"]

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+
+EXPOSE 8081
+
+CMD ["npx", "expo", "start", "--web", "--port", "8081"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  backend:
+    build:
+      context: .
+      dockerfile: Dockerfile.backend
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.frontend
+    ports:
+      - "8081:8081"
+    env_file:
+      - .env
+    depends_on:
+      - backend


### PR DESCRIPTION
Super basic .dockerignore file grabbed from stackoverflow.

Created dockerfiles for front and backend and an overall compose file in case we want to add additional services like Redis, our own MongoDB instance, etc.